### PR TITLE
Zeige Stub-Exits in neuen Räumen an.

### DIFF
--- a/build/MorgenGrauen/MorgenGrauen.xml
+++ b/build/MorgenGrauen/MorgenGrauen.xml
@@ -1242,6 +1242,12 @@ function getAnyExit(room, name)
     end
 end
 
+function addStubExit(src, name)
+    if not isSpecialExit(name) then
+      setExitStub(src, exitLoc2Num(name), true)
+    end
+end
+
 -- Erstellt einen neuen Raum mit Area und Hash und gibt eine Meldung aus.
 function createRoom(area, hash)
     local newRoom = createRoomID()
@@ -1291,6 +1297,10 @@ function handleRoomInfo()
             local newRoom = createRoom(mapper.currentArea, hash)
             local roomName = gmcp.MG.room.info.short
             setRoomName(newRoom, roomName)
+
+			for _, v in pairs(gmcp.MG.room.info.exits) do
+                addStubExit(newRoom, v)
+            end
 
             local x,y,z = getRoomCoordinates(mapper.currentRoom)
             local dx,dy,dz = getExitCoordinates(exitname)

--- a/version.md
+++ b/version.md
@@ -5,7 +5,7 @@ Autoren
 * Krrrcks@MorgenGrauen - https://github.com/krrrcks/krrrcks-mudlet
 * Zaphob@MorgenGrauen - https://github.com/kebap/krrrcks-mudlet
 * Talanis@MorgenGrauen - https://github.com/talanis85/krrrcks-mudlet
-
+* Brophy@MorgenGrauen - https://github.com/FGiesemann/mg-mudlet
 
 Versionen
 =========
@@ -72,3 +72,10 @@ Talanis
 * Erste Version eines Mappers.
 
 * Einfacher Speedwalker.
+
+
+Brophy
+------
+
+* Erweiterungen des Mappers um Stub-Exits und die Verwendung von Spezialausgängen
+  im Speedwalk


### PR DESCRIPTION
Der Mudlet-Mapper kann für einen Raum die möglichen Exits anzeigen,
auch wenn der Zielraum des Exits noch nicht bekannt ist. Dieser
Commit fügt die Fähigkeit für Standardausgänge (Himmelsrichtungen,
oben/unten, rein/raus) hinzu.