### PR TITLE
mmode zeigt aktuellen und mögliche Modus

### DIFF
--- a/src/aliases/mapper/Befehle/aliases.json
+++ b/src/aliases/mapper/Befehle/aliases.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "mmode",
-    "regex": "^mmode (.+)$"
+    "regex": "^mmode(?:\s+(.+))?$"
   },
   {
     "name": "marea",

--- a/src/scripts/mapper/Modes.lua
+++ b/src/scripts/mapper/Modes.lua
@@ -1,12 +1,16 @@
-
 -- Aendert den Mapper Mode und gibt eine entsprechende Meldung aus.
 function setMapperMode(mode)
+    if not mode then
+      echoM("Aktueller Modus: '" .. mapper.mode .. "'")
+    end
     if mode == "fix" or mode == "auto" then
-        echoM("Aendere Mapper-Modus nach: " .. mode)
-        mapper.mode = mode
+        if mode == mapper.mode then
+            echoM("Mapper-Modus war bereits: " .. mode)
+        else
+            echoM("Aendere Mapper-Modus nach: " .. mode)
+            mapper.mode = mode
+        end
     else
-        echoM("Fehler: Unbekannter Modus: '" .. mode .. "'")
+      echoM("Moegliche Modus: 'fix' und 'auto'")
     end
 end
-                    
-            


### PR DESCRIPTION
Bislang würde "mmode" allein keine Ausgabe erzeugen und man muss auswendig wissen, welche Modus als Argument funktionieren (fix und auto)

Ab sofort wird "mmode" ohne Argument den aktuellen Modus ausgeben, sowie ein falsches (oder kein) Argument bewirken, dass alle möglichen Modus aufgelistet werden.

Das könnte noch durch eine Lua Datenstruktur verschönert werden, aber für die bisher 2 Modus schien es überflüssig. Vielleicht beim nächsten Mal.