### PR TITLE
GMCP.Debug steuerbar & deaktiviert

### DIFF
--- a/src/aliases/mapper/Befehle/aliases.json
+++ b/src/aliases/mapper/Befehle/aliases.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "mmode",
-    "regex": "^mmode(?:\s+(.+))?$"
+    "regex": "^mmode(?:\\s+(.+))?$"
   },
   {
     "name": "marea",

--- a/src/aliases/mapper/Befehle/aliases.json
+++ b/src/aliases/mapper/Befehle/aliases.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "mmode",
-    "regex": "^mmode (.+)$"
+    "regex": "^mmode(?:\s+(.+))?$"
   },
   {
     "name": "marea",

--- a/src/scripts/krrrcks/GUI/initGMCP.lua
+++ b/src/scripts/krrrcks/GUI/initGMCP.lua
@@ -1,4 +1,5 @@
 function initGMCP() 
-    sendGMCP( [[Core.Supports.Debug 20 ]])
+    local debugLevel = 0 -- 0 zeigt nichts, 100 zeigt alles, 20 etwas, usw.
+    sendGMCP( f"Core.Debug {debugLevel} ")
     sendGMCP( [[Core.Supports.Set [ "MG.char 1", "MG.room 1", "comm.channel 1" ] ]])
 end

--- a/src/scripts/mapper/Modes.lua
+++ b/src/scripts/mapper/Modes.lua
@@ -1,12 +1,16 @@
-
 -- Aendert den Mapper Mode und gibt eine entsprechende Meldung aus.
 function setMapperMode(mode)
+    if not mode then
+      echoM("Aktueller Modus: '" .. mapper.mode .. "'")
+    end
     if mode == "fix" or mode == "auto" then
-        echoM("Aendere Mapper-Modus nach: " .. mode)
-        mapper.mode = mode
+        if mode == mapper.mode then
+            echoM("Mapper-Modus war bereits: " .. mode)
+        else
+            echoM("Aendere Mapper-Modus nach: " .. mode)
+            mapper.mode = mode
+        end
     else
-        echoM("Fehler: Unbekannter Modus: '" .. mode .. "'")
+      echoM("Moegliche Modus: 'fix' und 'auto'")
     end
 end
-                    
-            


### PR DESCRIPTION
Dank https://github.com/Kebap/krrrcks-mudlet/issues/75 konnte der Debug-Modus für GMCP erstmalig seit 8 Jahren aktiviert werden. Er ist nun leicht per Variable regelbar. 

Im Standard ist er jedoch deaktiviert (so wie er es durch den Fehler bis dato sowieso war), da für "normale" Spieler uninteressant sein sollte. Interessierte können ihn schnell aktivieren.