### PR TITLE
Web-Links klickbar machen

### DIFF
--- a/src/triggers/Klickbare Links/http(s) und www.lua
+++ b/src/triggers/Klickbare Links/http(s) und www.lua
@@ -1,0 +1,10 @@
+local site = matches[1]
+selectString(site, 1)
+if string.starts(string.lower(site),"www") then
+  site = "http://" .. string.lower(site)
+end
+setUnderline(true)
+
+local command = string.format( [[openWebPage("%s")]], site )
+setLink(command, f"Link {site} im Browser öffnen.")
+resetFormat()

--- a/src/triggers/Klickbare Links/mg@mud.de.lua
+++ b/src/triggers/Klickbare Links/mg@mud.de.lua
@@ -1,0 +1,6 @@
+selectString(matches[1], 1)
+setUnderline(true)
+
+local command = string.format( [[openWebPage("mailto:%s")]], matches[1] )
+setLink(command, "Email ans MorgenGrauen Team senden.")
+resetFormat()

--- a/src/triggers/Klickbare Links/triggers.json
+++ b/src/triggers/Klickbare Links/triggers.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "http(s) und www",
+    "highlight": "no",
+    "patterns": [ 
+      {
+        "pattern": "(?i:https?:\\/\\/\\S*)",
+        "type": "regex",
+        "comment": "accepted trigger types are 'substring', 'regex', 'startOfLine', 'exactMatch', 'lua', 'spacer', 'color', 'colour', and 'prompt'"
+      },
+      {
+        "pattern": "(?i:www\\.\\S*)",
+        "type": "regex"
+      }
+    ]
+  },
+  {
+    "name": "mud@mg.mud.de",
+    "patterns": [
+      {
+        "pattern": "mud@mg.mud.de",
+        "type": "substring"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Web-Links nach folgendem Muster kann man jetzt anklicken, um damit den Browser zu öffnen:
* www.*
* http://*
* https://*

Fix https://github.com/Kebap/krrrcks-mudlet/issues/43