### PR TITLE
Update minit.lua

### DIFF
--- a/src/aliases/mapper/Befehle/minit.lua
+++ b/src/aliases/mapper/Befehle/minit.lua
@@ -27,6 +27,7 @@ end
 
 -- currentArea zurücksetzen damit wir wirklich von vorne anfangen
 mapper.currentArea = "world"
+mapper.currentHash = nil
 
 -- MapUserData löschen
 clearMapUserData()
@@ -37,7 +38,7 @@ if isField(gmcp, "MG.room.info") then
     local hash = roomData.id
 
     mapper.currentHash = hash
-    
+
     local newRoom = createRoom(mapper.currentArea, hash)
 
     setRoomName(newRoom, roomData.short)
@@ -51,13 +52,9 @@ if isField(gmcp, "MG.room.info") then
     centerview(newRoom)
 else
     -- keine Raumdaten vorhanden
-    mapper.currentHash = nil
-
-    local newRoom = createRoomID()
-    addRoom(newRoom)
-    setRoomArea(newRoom, findArea(mapper.currentArea))
+    local newRoom = createRoom(mapper.currentArea, mapper.currentHash)
     
-    echoM("Erstelle unbekannten Raum.\n  Area: " .. mapper.currentArea)
+    setRoomName(newRoom, "Irgendwo im Nirgendwo")
 
     mapper.currentRoom = newRoom
     centerview(newRoom)

--- a/src/aliases/mapper/Befehle/minit.lua
+++ b/src/aliases/mapper/Befehle/minit.lua
@@ -61,3 +61,4 @@ else
 end
 
 echoM("Neue Karte initialisiert.")
+setMapperMode("auto")

--- a/src/aliases/mapper/Befehle/minit.lua
+++ b/src/aliases/mapper/Befehle/minit.lua
@@ -1,7 +1,7 @@
 -- Dies setzt die Karte auf Werkszustand zurueck.
 
 -- Sonderfälle, behandeln wir irgendwann in der Zukunft
-if not gmcp.MG.room.info == nil or gmcp.MG.room.info.id == nil then
+if gmcp.MG.room.info == nil or gmcp.MG.room.info.id == nil then
     echoM("Bitte begebe dich in einen anderen Raum und versuche es noch einmal! Habe derzeit keinerlei Informationen ueber deinen aktuellen Standort im MorgenGrauen :(")
     return
 end

--- a/src/aliases/mapper/Befehle/minit.lua
+++ b/src/aliases/mapper/Befehle/minit.lua
@@ -1,16 +1,41 @@
-
 -- Dies setzt die Karte auf Werkszustand zurueck.
 
-for i,name in pairs(getRooms()) do
-    deleteRoom(i)
+-- Sonderfälle, behandeln wir irgendwann in der Zukunft
+if not gmcp.MG.room.info == nil or gmcp.MG.room.info.id == nil then
+    echoM("Bitte begebe dich in einen anderen Raum und versuche es noch einmal! Habe derzeit keinerlei Informationen ueber deinen aktuellen Standort im MorgenGrauen :(")
+    return
 end
 
-addRoom(1)
-setRoomArea(1, findArea("world"))
-setRoomIDbyHash(1, mapper.currentHash)
-mapper.currentRoom = 1
-centerview(1)
+-- vorhandene Räume löschen
+for id, _ in pairs(getRooms()) do
+    deleteRoom(id)
+end
 
-echoM("Neue Map initialisiert.")
-                    
-                
+-- vorhandene Gebiete löschen, ausser "Default Area"
+for _, id in pairs(getAreaTable()) do
+    if id > -1 then
+        deleteArea(id)
+    end
+end
+
+-- MapUserData löschen
+clearMapUserData()
+
+-- ersten Raum aus aktuellen GMCP Daten erstellen
+local hash = gmcp.MG.room.info.id
+
+mapper.currentHash = hash
+
+local newRoom = createRoom(mapper.currentArea, hash)
+local roomName = gmcp.MG.room.info.short
+setRoomName(newRoom, roomName)
+
+-- im neuen Raum alle sichtbaren Ausgänge prüfen und ggf. Stubs erzeugen
+for _, exitname in pairs(gmcp.MG.room.info.exits) do
+    addStubExit(newRoom, exitname)
+end
+
+mapper.currentRoom = newRoom
+centerview(newRoom)
+
+echoM("Neue Karte initialisiert.")

--- a/src/scripts/mapper/Ausgaenge.lua
+++ b/src/scripts/mapper/Ausgaenge.lua
@@ -163,7 +163,14 @@ function createRoom(area, hash)
     local newRoom = createRoomID()
     addRoom(newRoom)
     setRoomArea(newRoom, findArea(area))
-    setRoomIDbyHash(newRoom, hash)
+
+    if hash ~= nil then 
+        setRoomIDbyHash(newRoom, hash) 
+    else
+        -- just für die folgende Meldung...
+        hash = "ohne Hash"
+    end
+
     echoM("Erstelle Raum.\n  Area: " .. area .. "\n  Hash: " .. hash)
     return newRoom
 end

--- a/src/scripts/mapper/handleRoomInfo.lua
+++ b/src/scripts/mapper/handleRoomInfo.lua
@@ -28,15 +28,37 @@ function handleRoomInfo()
         if knownRoom == -1 then
             -- Neuer Raum ist nicht bekannt. Erstelle Raum und entsprechenden Ausgang
 
-            local newRoom = createRoom(mapper.currentArea, hash)
+            local needsUpdate = getRoomHashByID(mapper.currentRoom) == nil
+            local newRoom
+
+            if needsUpdate then
+                -- wir befinden uns wahrschenlich im ersten erstellten Raum, der allerdings
+                -- ein Sonderraum war...
+
+                newRoom = mapper.currentRoom
+                
+                setRoomArea(newRoom, findArea(mapper.currentArea))
+
+                setRoomIDbyHash(newRoom, hash)
+    
+                echoM("Aktualisiere Raum.\n  Area: " .. mapper.currentArea .. "\n  Hash: " .. hash)
+            else
+                newRoom = createRoom(mapper.currentArea, hash)
+            end
+
             local roomName = gmcp.MG.room.info.short
             setRoomName(newRoom, roomName)
 
-            local x,y,z = getRoomCoordinates(mapper.currentRoom)
-            local dx,dy,dz = getExitCoordinates(exitname)
-            setRoomCoordinates(newRoom, x+dx, y+dy, z+dz)
+            if not needsUpdate then
+                -- bei Raumupdates brauchen wir keine neuen Koordinaten setzen
+                local x,y,z = getRoomCoordinates(mapper.currentRoom)
+                local dx,dy,dz = getExitCoordinates(exitname)
+                setRoomCoordinates(newRoom, x+dx, y+dy, z+dz)
 
-            addAnyExit(mapper.currentRoom, newRoom, exitname)
+                -- auch brauchen wir keinen Ausgang, haben ja den Raum auf der Karte nicht gewechselt
+                addAnyExit(mapper.currentRoom, newRoom, exitname)
+            end
+
             mapper.currentRoom = newRoom
         else
             -- Neuer Raum ist bekannt. Erstelle nur einen Ausgang.


### PR DESCRIPTION
Das *minit* Alias soll eigentlich eine eventuell vorhandene Karte löschen und alles fürs Automapping vorbereiten. Leider werden weder eventuell vorhandene Regionen (areas) inklusive ihrer AreaUserData, noch eventuell vorhandene MapUserInfo entfernt. Auch bekommt der hier erstellte Raum weder seinen per GMCP übermittelten Raumnamen, noch werden die sichtbaren Ausgänge erstellt. mapper.currentHash wird auch nicht festgelegt, was in bestimmten Fällen zu doppelten Räumen an den selben Koordinaten führen könnte sobald komplexere Features eingebaut werden.

Sobald wir anfangen die Möglichkeiten des Mudlet Mappers für interessante Features (z.B. Speedwalk Aliase, Raumnotizen, Schnellreisefavouriten, ...) zu nutzen kann uns all das ordentlich in den Allerwertesten zwicken.

Meine vorgeschlagenen Änderungen ziehen übrigens nicht alle Sonderfälle (z.B. Finsternis) in Betracht. Darum wird sich später gekümmert ;)

Änderungen:

- minit gibt eine Fehlermeldung aus wenn keine Rauminfos per GMCP angekommen sind (Sonderfälle)
- Räume, Areas und *UserInfos werden gelöscht, bis auf die DefaultArea (-1)
- der erste Raum wird mit allen aktuellen Rauminformationen erstellt (also auch Raumname und Ausgangsstubs)
  - edit: Falls gerade noch nicht alle Daten verfügbaren sind, wird ein Sonderraum erstellt und ganz korrekt in die Karte eingebaut, und in handleRoomInfo() wird er nachträglich aktualisiert (anstelle einen neuen Raum zu erstellen und den unvollständigen Raum als Karteileiche zu behalten).
- mapper.currentHash wird gesetzt
- edit: Der Mapmodus wird jetzt in minit auf Auto gestellt, damit man das nicht mehr vergisst und erst einige Räume später macht