### PR TITLE
Einstellungen nicht dauernd neu initialisieren

### DIFF
--- a/src/scripts/krrrcks/Einstellungen/Spieler.lua
+++ b/src/scripts/krrrcks/Einstellungen/Spieler.lua
@@ -1,16 +1,16 @@
 -- Variablen zum Spieler
 
-ME = {}
-ME.name = "Jemand"
-ME.stufe = 0
+ME = ME or {}
+ME.name = ME.name or "Jemand"
+ME.stufe = ME.stufe or 0
 
-ME.para = 0
-ME.vorsicht = 0
-ME.fluchtrichtung = ""
-ME.lp_alt = 0
+ME.para = ME.para or 0
+ME.vorsicht = ME.vorsicht or 0
+ME.fluchtrichtung = ME.fluchtrichtung or ""
+ME.lp_alt = ME.lp_alt or 0
 
-GUI = {}
-GUI.angezeigt = false
-GUI.lp_anzeige_blinkt = false
+GUI = GUI or {}
+GUI.angezeigt = GUI.angezeigt or false
+GUI.lp_anzeige_blinkt = GUI.lp_anzeige_blinkt or false
 
-wege = {}
+wege = wege or {}

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -5,11 +5,11 @@ uninstallPackage("generic_mapper")
 mudlet = mudlet or {}
 mudlet.mapper_script = true
 
-mapper = {}
+mapper = mapper or {}
 
-mapper.mode = "fix"
-mapper.currentHash = nil
-mapper.currentArea = "world"
+mapper.mode = mapper.mode or "fix"
+mapper.currentHash = mapper.currentHash or nil
+mapper.currentArea = mapper.currentArea or "world"
 
 function echoM(str)
     fg(mapperconf.color)


### PR DESCRIPTION
Wenn man durch die Skripte klickt, überschreibt man versehentlich die Einstellungen mit den Standardwerten.

Dies ist ein kleiner Fix, um das zu unterbinden. Langfristig sollte das nur einmalig bei Setup oder eben auf expliziten Wunsch geschehen, also die Kommandos nicht einfach im Skript außerhalb irgendeiner Funktion stehen.