### PR TITLE
Aktuellen Kartenmodus auf der Karte anzeigen

### DIFF
--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -11,6 +11,16 @@ mapper.mode = "fix"
 mapper.currentHash = nil
 mapper.currentArea = "world"
 
+-- Den aktuellen Kartenmodus in der Karte anzeigen
+registerMapInfo("Kartenmodus", function() 
+    if mapper.mode == "fix" then
+        return "", false, true, unpack(color_table.tomato)
+    else
+        return "Kartenmodus: automatisch erweitern", false, true, unpack(color_table.tomato)
+    end
+end)
+enableMapInfo("Kartenmodus")
+
 function echoM(str)
     fg(mapperconf.color)
     echo("[MAPPER] " .. str .. "\n")

--- a/src/scripts/mapper/Modes.lua
+++ b/src/scripts/mapper/Modes.lua
@@ -9,6 +9,8 @@ function setMapperMode(mode)
         else
             echoM("Aendere Mapper-Modus nach: " .. mode)
             mapper.mode = mode
+            
+            updateMap() -- nur für die Anzeige vom Kartenmodus
         end
     else
       echoM("Moegliche Modus: 'fix' und 'auto'")


### PR DESCRIPTION
Was bei mir immer wieder für Verwirrung sorgt ist der Kartenmodus. Deshalb hier ein kleines Gimmick:

<img width="421" alt="screenshot-display-mmode" src="https://user-images.githubusercontent.com/229010/123546693-fc508d80-d75d-11eb-9833-6bbcb483db9e.png">

Er wird aber nur angezeigt wenn er auf "auto" steht um die Karte bei normaler Nutzung nicht vollzumüllen. Möglich wäre es aber auch ihn bei "fix" z.B. in grün anzuzeigen? Oder gar eine Option: Kartenmodus immer anzeigen?