### PR TITLE
Unterstützung für Discord Rich Presence

### DIFF
--- a/src/scripts/Discord/resetDiscordData.lua
+++ b/src/scripts/Discord/resetDiscordData.lua
@@ -1,0 +1,10 @@
+function resetDiscordData()
+  -- Alles auf Standard zurücksetzen
+  setDiscordApplicationID()
+  setDiscordDetail("www.mudlet.org")
+  setDiscordState("")
+  setDiscordLargeIcon("server-icon")
+  setDiscordLargeIconText("")
+  setDiscordSmallIcon("")
+  setDiscordSmallIconText("")
+end

--- a/src/scripts/Discord/scripts.json
+++ b/src/scripts/Discord/scripts.json
@@ -19,12 +19,14 @@
     },
     {
         "name": "setDiscordRaum",
+        "isActive": "no",
         "eventHandlerList": [
             "gmcp.MG.room"
           ]
     },
     {
         "name": "setDiscordLP",
+        "isActive": "no",
         "eventHandlerList": [
             "gmcp.MG.char.vitals",
             "gmcp.MG.char.maxvitals"

--- a/src/scripts/Discord/scripts.json
+++ b/src/scripts/Discord/scripts.json
@@ -1,0 +1,39 @@
+[
+    {
+        "name": "setDiscordMG",
+        "eventHandlerList": [
+            "gmcp.MG"
+          ]
+    },
+    {
+        "name": "setDiscordStufe",
+        "eventHandlerList": [
+            "gmcp.MG.char.info.level"
+          ]
+    },
+    {
+        "name": "setDiscordGuild",
+        "eventHandlerList": [
+            "gmcp.MG.char.base.guild"
+          ]
+    },
+    {
+        "name": "setDiscordRaum",
+        "eventHandlerList": [
+            "gmcp.MG.room"
+          ]
+    },
+    {
+        "name": "setDiscordLP",
+        "eventHandlerList": [
+            "gmcp.MG.char.vitals",
+            "gmcp.MG.char.maxvitals"
+          ]
+    },
+    {
+        "name": "showDiscordTexts"
+    },
+    {
+        "name": "resetDiscordData"
+    }
+]

--- a/src/scripts/Discord/setDiscordGuild.lua
+++ b/src/scripts/Discord/setDiscordGuild.lua
@@ -1,0 +1,21 @@
+local symbole = {
+  kaempfer = "schwerter",
+  abenteurer = "kompass",
+  zauberer = "zauberer",
+  chaos = "teufel",
+  urukhai = "ork",
+  bierschuettler = "bier",
+  katzenkrieger = "tatzen",
+  wipfellaeufer = "baum",
+  dunkelelfen = "spinne",
+  tanjian = "waage",
+  karate = "karate",
+  klerus = "heilig",
+  werwoelfe = "wolf",
+}
+
+function setDiscordGuild()
+  -- Anzeige von passenden kleinen Bildchen je nach Gilde
+  local meinSymbol = symbole[gmcp.MG.char.base.guild] or "glitzer"
+  setDiscordSmallIcon(meinSymbol)
+end

--- a/src/scripts/Discord/setDiscordLP.lua
+++ b/src/scripts/Discord/setDiscordLP.lua
@@ -1,0 +1,8 @@
+-- Lebenspunkte sind umstritten, erstmal deaktivieren!
+local LPVeroeffentlichen = false
+
+function setDiscordLP()
+  if LPVeroeffentlichen then
+    setDiscordParty(ME.lp, ME.lp_max)
+  end
+end

--- a/src/scripts/Discord/setDiscordMG.lua
+++ b/src/scripts/Discord/setDiscordMG.lua
@@ -1,0 +1,19 @@
+local zeigeMorgenGrauenInDiscord = true
+
+function setDiscordMG()
+  if not zeigeMorgenGrauenInDiscord then return end
+  setDiscordApplicationID("447501514915971072") -- setze MorgenGrauen (oder "" für Mudlet)
+  -- usingMudletsDiscordID() -- prüft, ob MorgenGrauen oder Mudlet angezeigt wird
+  setDiscordDetail("www.MorgenGrauen.info")
+  setDiscordState("via Mudlet")
+  setDiscordLargeIcon("drache")
+  setDiscordLargeIconText("telnet mg.mud.de:4711")
+  if gmcp and gmcp.MG and gmcp.MG.char then
+    if gmcp.MG.char.info and gmcp.MG.char.info.level then
+      setDiscordStufe()
+    end
+    if gmcp.MG.char.base and gmcp.MG.char.base.guild then
+      setDiscordGuild()
+    end
+  end
+end

--- a/src/scripts/Discord/setDiscordRaum.lua
+++ b/src/scripts/Discord/setDiscordRaum.lua
@@ -1,0 +1,9 @@
+-- Raum ist umstritten, erstmal deaktivieren!
+local RaumVeroeffentlichen = false
+
+function setDiscordRaum()
+  if RaumVeroeffentlichen then
+    setDiscordDetail(ME.raum_kurz)
+    setDiscordState(ME.raum_region)
+  end
+end

--- a/src/scripts/Discord/setDiscordStufe.lua
+++ b/src/scripts/Discord/setDiscordStufe.lua
@@ -1,0 +1,4 @@
+function setDiscordStufe()
+  -- Stufe aufgestiegen? Grats! Dann aktualisieren:
+  setDiscordSmallIconText("Stufe " .. gmcp.MG.char.info.level)
+end

--- a/src/scripts/Discord/showDiscordTexts.lua
+++ b/src/scripts/Discord/showDiscordTexts.lua
@@ -1,0 +1,11 @@
+function showDiscordTexts()
+  print("Detail: ", getDiscordDetail())
+  print("State: ", getDiscordState())
+  print("Large Icon: ", getDiscordLargeIcon())
+  print("Large Icon Text: ", getDiscordLargeIconText())
+  print("Small Icon: ", getDiscordSmallIcon())
+  print("Small Icon Text: ", getDiscordSmallIconText())
+  print("Time Stamps: ", getDiscordTimeStamps())
+  print("Party: ", getDiscordParty())
+  print("\n")
+end


### PR DESCRIPTION
Mit diesen Änderungen kann man im Discord zeigen, dass man MorgenGrauen spielt (und nicht bloß Mudlet).

Nach den letzten Diskussionen im Spiel werden nun keine Daten zu aktuellen Lebenspunkten und/oder Aufenthaltsort im Spiel übertragen (obwohl oder gerade weil sich diese recht oft ändern und schnell in Discord aktualisiert wurden, was dort interessierte Zuschauer anlockt)

Trotz intensivem Brainstorm sind noch keine weiteren aktuellen Infos eingefallen, die dort zum Spieler gezeigt werden könnten, daher bleibt erstmal nur der Link auf die Onlinepräsenz des MorgenGrauen.

Andere Spiele bieten zB eine "Hier klicken um mitzumachen"-Funktion, aber die fehlt fürs MorgenGrauen bis dato. 

Außerdem gibt es einige neue Kommandos:
- `setDiscordMG()` - wird automatisch aufgerufen und richtet alle Infos ein
- `showDiscordTexts()` - zeigt die Daten, die von Mudlet an Discord gehen und dort angezeigt werden (würden, falls man es dort deaktiviert hat)
- `resetDiscordData()`- wird direkt alles auf Standard zurücksetzen, als hätte man nie MorgenGrauen gespielt

Vorher:
![image](https://user-images.githubusercontent.com/117238/124338033-10551e80-dba6-11eb-97ba-e6948b4e60d2.png)

Nachher:
![image](https://user-images.githubusercontent.com/117238/124338038-1b0fb380-dba6-11eb-996d-731e832d6f90.png)

Bzw. im "light" theme:
![image](https://user-images.githubusercontent.com/117238/124338101-5f02b880-dba6-11eb-822e-bbe6aa938fc2.png)
