### PR TITLE
Ebenen etwas weniger grell anzeigen

### DIFF
--- a/src/scripts/settings/Einstellungen/Farben.lua
+++ b/src/scripts/settings/Einstellungen/Farben.lua
@@ -2,7 +2,7 @@
 farben = {}
 farben.vg = 
   { komm = "cyan",
-    ebenen = "magenta",
+    ebenen = "hot_pink",
     info = "green",
     alarm = "white",
     script = "dark_green" }


### PR DESCRIPTION
Es gab Beschwerden, dass Magenta auf Schwarz beißt, daher die Farbe im Standard leicht verändert.

Freu mich auf die leichtere Konfiguration mit #17 durch die die Spieler hier viel autonomer werden!