### PR TITLE
Optionale Reports berücksichtigen

### DIFF
--- a/src/scripts/krrrcks/GUI/initBase.lua
+++ b/src/scripts/krrrcks/GUI/initBase.lua
@@ -1,4 +1,5 @@
 function initBase() 
+  if gmcp.MG.char.base and gmcp.MG.char.info then
     ME.name = gmcp.MG.char.base.name 
     ME.stufe = gmcp.MG.char.info.level
 
@@ -6,5 +7,5 @@ function initBase()
         initGUI()
         GUI.angezeigt = true
     end
-
+  end
 end

--- a/src/scripts/krrrcks/GUI/zeigeGift.lua
+++ b/src/scripts/krrrcks/GUI/zeigeGift.lua
@@ -1,4 +1,6 @@
 function zeigeGift()
+  
+  if not GUI.gift then return end
 
   ME.gift = gmcp.MG.char.vitals.poison
   local zeile = ""

--- a/src/scripts/krrrcks/GUI/zeigeVitaldaten.lua
+++ b/src/scripts/krrrcks/GUI/zeigeVitaldaten.lua
@@ -1,4 +1,6 @@
 function zeigeVitaldaten()
+  
+  if not (gmcp.MG.char.vitals and gmcp.MG.char.maxvitals) then return end
 
   -- GMCP Vitaldaten merken
 

--- a/src/scripts/krrrcks/GUI/zeigeVitaldaten.lua
+++ b/src/scripts/krrrcks/GUI/zeigeVitaldaten.lua
@@ -1,7 +1,8 @@
 function zeigeVitaldaten()
-  
-  if not (gmcp.MG.char.vitals and gmcp.MG.char.maxvitals) then return end
 
+  if not (gmcp.MG.char.vitals and gmcp.MG.char.maxvitals
+          and GUI.lp_anzeige and GUI.kp_anzeige) then return end
+  
   -- GMCP Vitaldaten merken
 
   ME.lp = gmcp.MG.char.vitals.hp

--- a/src/scripts/krrrcks/GUI/zeigeVitaldaten.lua
+++ b/src/scripts/krrrcks/GUI/zeigeVitaldaten.lua
@@ -4,16 +4,22 @@ function zeigeVitaldaten()
 
   ME.lp = gmcp.MG.char.vitals.hp
   ME.lp_max = gmcp.MG.char.maxvitals.max_hp
-  ME.kp = gmcp.MG.char.vitals.sp
+  local lp_anzeigetext = "<b> " .. ME.lp .. "/" .. ME.lp_max .. "</b> "
+  
   ME.kp_max = gmcp.MG.char.maxvitals.max_sp
+  local kp_anzeigetext
+  -- Vielleicht hat der Spieler noch keinen KP-Report!
+  if gmcp.MG.char.vitals.sp then
+    ME.kp = gmcp.MG.char.vitals.sp
+    kp_anzeigetext = "<b> " .. ME.kp .. "/" .. ME.kp_max .. "</b> "
+  else
+    ME.kp = ME.kp_max
+    kp_anzeigetext = "<b> max. " .. ME.kp .. "</b> "
+  end
 
   -- Werte der Balken aktualisieren
-  
-  GUI.lp_anzeige:setValue(ME.lp, ME.lp_max, 
-      "<b> " .. ME.lp .. "/" .. ME.lp_max .. "</b> ")
-
-  GUI.kp_anzeige:setValue(ME.kp, ME.kp_max, 
-      "<b> " .. ME.kp .. "/" .. ME.kp_max .. "</b> ")
+  GUI.lp_anzeige:setValue(ME.lp, ME.lp_max, lp_anzeigetext)
+  GUI.kp_anzeige:setValue(ME.kp, ME.kp_max, kp_anzeigetext)
 
   -- Treffer? Dann LP Balken blinken lassen
 

--- a/src/scripts/krrrcks/GUI/zeigeVorsicht.lua
+++ b/src/scripts/krrrcks/GUI/zeigeVorsicht.lua
@@ -1,24 +1,25 @@
 function zeigeVorsicht()
 
-  ME.vorsicht = gmcp.MG.char.wimpy.wimpy
-  ME.fluchtrichtung = gmcp.MG.char.wimpy.wimpy_dir
-
-  -- Prinz Eisenherz?
-
-  if ME.vorsicht == 0 then
-    ME.vorsicht = "NIX"
+  if gmcp.MG.char.wimpy and gmcp.MG.char.wimpy.wimpy and gmcp.MG.char.wimpy.wimpy_dir then 
+    ME.vorsicht = gmcp.MG.char.wimpy.wimpy
+    ME.fluchtrichtung = gmcp.MG.char.wimpy.wimpy_dir
+  
+    -- Prinz Eisenherz?
+  
+    if ME.vorsicht == 0 then
+      ME.vorsicht = "NIX"
+    end
+  
+    local zeile = "Vorsicht: " .. ME.vorsicht
+  
+    -- Fluchtrichtung anzeigen, nur wenn gesetzt
+  
+    if ME.fluchtrichtung ~= 0 then
+      zeile = zeile .. ", FR: " .. ME.fluchtrichtung
+    end
+  
+    -- Statuszeile aktualisieren
+  
+    GUI.vorsicht:echo(zeile)
   end
-
-  local zeile = "Vorsicht: " .. ME.vorsicht
-
-  -- Fluchtrichtung anzeigen, nur wenn gesetzt
-
-  if ME.fluchtrichtung ~= 0 then
-    zeile = zeile .. ", FR: " .. ME.fluchtrichtung
-  end
-
-  -- Statuszeile aktualisieren
-
-  GUI.vorsicht:echo(zeile)
-
 end


### PR DESCRIPTION
Wenn ein Spieler noch keine KP (und/oder Gifte? Fluchtrichtung?) berichtet bekommt, dann warf das Paket Fehler.
Außerdem wurde versucht, die GUI zu aktualisieren, bevor sie überhaupt fertig erstellt worden ist.

Bei Login:

```
Du nimmst schon am Spiel teil!
Verwende Deine alte sterbliche Huelle ...
Finsternis.
> 
[  LUA  ] - object: <event handler function> function:<initBase>
            <[string "Script: initBase"]:2: attempt to index field 'base' (a nil value)>
[  LUA  ] - object: <event handler function> function:<zeigeVitaldaten>
            <[string "Script: zeigeVitaldaten"]:5: attempt to index field 'vitals' (a nil value)>
[  LUA  ] - object: <event handler function> function:<zeigeVitaldaten>
            <[string "Script: zeigeVitaldaten"]:21: attempt to index field 'lp_anzeige' (a nil 
value)>
[  LUA  ] - object: <event handler function> function:<zeigeGift>
            <[string "Script: zeigeGift"]:21: attempt to index field 'gift' (a nil value)>
[  LUA  ] - object: <event handler function> function:<zeigeVorsicht>
            <[string "Script: zeigeVorsicht"]:17: attempt to concatenate field 'fluchtrichtung' (a 
nil value)>
[  LUA  ] - object: <event handler function> function:<zeigeVorsicht>
            <[string "Script: zeigeVorsicht"]:17: attempt to concatenate field 'fluchtrichtung' (a 
nil value)>
[  LUA  ] - object: <event handler function> function:<zeigeVorsicht>
            <[string "Script: zeigeVorsicht"]:17: attempt to concatenate field 'fluchtrichtung' (a 
nil value)>
```

Im Spiel:
``` 
> vorsicht 20
[  LUA  ] - object: <event handler function> function:<zeigeVorsicht>
            <[string "Script: zeigeVorsicht"]:17: attempt to concatenate field 'fluchtrichtung' (a 
nil value)>
Vorsicht-Modus (20)
``` 

Im Kampf war auch noch was in jeder Runde (Vielleicht, wenn KP sich ändern?)

Dank an @jexp für den Bugreport