### PR TITLE
zeige Discord Link

### DIFF
--- a/src/scripts/Discord/scripts.json
+++ b/src/scripts/Discord/scripts.json
@@ -36,6 +36,9 @@
         "name": "showDiscordTexts"
     },
     {
+        "name": "showDiscordLink"
+    },
+    {
         "name": "resetDiscordData"
     }
 ]

--- a/src/scripts/Discord/setDiscordLink
+++ b/src/scripts/Discord/setDiscordLink
@@ -1,0 +1,8 @@
+-- Link zum Discord des MorgenGrauen im Mudlet Menu anzeigen
+local LinkAnzeigen = true
+
+function setDiscordLink()
+  if LinkAnzeigen then
+    setDiscordGameUrl("https://discord.gg/nHJnYHk", "MorgenGrauen")
+  end
+end

--- a/src/scripts/Discord/setDiscordMG.lua
+++ b/src/scripts/Discord/setDiscordMG.lua
@@ -8,6 +8,7 @@ function setDiscordMG()
   setDiscordState("via Mudlet")
   setDiscordLargeIcon("drache")
   setDiscordLargeIconText("telnet mg.mud.de:4711")
+  setDiscordLink()
   if gmcp and gmcp.MG and gmcp.MG.char then
     if gmcp.MG.char.info and gmcp.MG.char.info.level then
       setDiscordStufe()


### PR DESCRIPTION
Biete einen einfachen Absprung aus Mudlet zum Discord des MorgenGrauen:

![image](https://user-images.githubusercontent.com/117238/168455639-590c1cf6-a0c9-4258-b6a3-a59dd4fcd1ba.png)

Setup ist manuell auch einfach:
`lua setDiscordGameUrl("https://discord.gg/nHJnYHk", "MorgenGrauen")`