### PR TITLE
GMCP Initialisierung deaktiviert nun "Char" Modul

### DIFF
--- a/src/scripts/krrrcks/GUI/initGMCP.lua
+++ b/src/scripts/krrrcks/GUI/initGMCP.lua
@@ -5,3 +5,23 @@ function initGMCP(_, protocol)
         sendGMCP( [[Core.Supports.Set [ "MG.char 1", "MG.room 1", "comm.channel 1" ] ]])
     end
 end
+
+function GMCP_Char_deaktivieren(_)
+    -- gmcp.Char wird bei Login dreimal empfangen: StatusVars, Status, Vitals
+    -- Hintergrund ist, dass Mudlet das automatisch im GMCP Handshake anfordert.
+    -- Dies ist unabhängig von ggf. Lua Skripten und fragt immer nach "Char".
+    -- Hintergrund ist gewünschtes "einfaches, out-of-the-box" Erlebnis bei vielen Spielen.
+    -- Passt aber nicht zu MG.char also werden wir den Inhalt wieder löschen.
+    -- Damit wir nicht dreimal löschen, hier ein Timer mit Wartezeit von null Sekunden.
+
+    if not GMCP_Char_Timer then 
+      GMCP_Char_Timer = tempTimer(0, function()
+        GMCP_Char_Timer = nil
+        gmcp.Char = nil
+        -- debugText("GMCP Char deaktiviert!")
+      end)
+    end 
+  end
+
+registerAnonymousEventHandler("sysProtocolEnabled", "initGMCP")
+registerAnonymousEventHandler("gmcp.Char", "GMCP_Char_deaktivieren")

--- a/src/scripts/krrrcks/GUI/scripts.json
+++ b/src/scripts/krrrcks/GUI/scripts.json
@@ -1,9 +1,6 @@
 [
   {
-    "name": "initGMCP",
-    "eventHandlerList": [ 
-      "sysProtocolEnabled"
-    ]
+    "name": "initGMCP"
   },
   {
     "name": "initBase",


### PR DESCRIPTION
gmcp.Char wird bei Login dreimal empfangen: StatusVars, Status, Vitals
Hintergrund ist, dass Mudlet das automatisch im GMCP Handshake anfordert.
Dies ist unabhängig von ggf. Lua Skripten und fragt immer nach "Char".
Hintergrund ist gewünschtes "einfaches, out-of-the-box" Erlebnis bei vielen Spielen.
Passt aber nicht zu MG.char also werden wir den Inhalt wieder löschen.

Außerdem wird die Funktion "initGMCP" nun nicht mehr durch "scripts.json" an das Event "sysProtocolEnabled" gebunden, sondern direkt per Lua-Befehl im Skript selbst.
Dadurch wird das Skript einerseits übersichtlicher.
Andererseits verschwindet das Event aus der Handler-Liste in der Skript-GUI in Mudlet.
Das Skript und die Funktion können damit in Zukunft auch andere Namen tragen.