### PR TITLE
Farbige Texte durch einheitliche Funktionen realisieren

### DIFF
--- a/src/scripts/krrrcks/GUI/zeigeEbenen.lua
+++ b/src/scripts/krrrcks/GUI/zeigeEbenen.lua
@@ -1,3 +1,3 @@
 function zeigeEbenen()
-  text_faerben("ebenen", gmcp.comm.channel.msg)
+  faerbeText("ebenen", gmcp.comm.channel.msg)
 end

--- a/src/scripts/krrrcks/GUI/zeigeEbenen.lua
+++ b/src/scripts/krrrcks/GUI/zeigeEbenen.lua
@@ -1,6 +1,3 @@
 function zeigeEbenen()
-  fg(farben.vg.ebenen)
-  bg(farben.hg.ebenen)
-  echo(gmcp.comm.channel.msg)
-  resetFormat()
+  text_faerben("ebenen", gmcp.comm.channel.msg)
 end

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -22,6 +22,8 @@ end)
 enableMapInfo("Kartenmodus")
 
 function echoM(str)
+    -- TODO: Mit faerbeText() harmonisieren..!
+    -- TODO: Mapper-Infos in Debug-Tab hinter Mapper verschieben?
     fg(mapperconf.color)
     echo("[MAPPER] " .. str .. "\n")
     resetFormat()

--- a/src/scripts/settings/Einstellungen/Farben.lua
+++ b/src/scripts/settings/Einstellungen/Farben.lua
@@ -25,7 +25,7 @@ farben = farben or
 
 -- Einstellungen fuer Farben Kampfscroll
 
-function text_faerben(type, text)
+function faerbeText(type, text)
   -- setzt Vordergrund- und Hintergrundfarbe je nach Typ der Kommunikation, und schreibt dann den Text in bunt 
   local vg = farben.vg[type]
   local hg = farben.hg[type]
@@ -36,7 +36,7 @@ function text_faerben(type, text)
   end
 end
 
-function zeile_faerben(type)
+function faerbeZeile(type)
   -- ändert Vordergrund- und Hintergrundfarbe der aktuellen (ganzen) Zeile je nach Typ der Kommunikation
   -- Keine Ahnung, ob das besser geht, aber ich will die ganze Zeile einfärben und nicht nur den "Match".
   local vg = farben.vg[type]
@@ -49,7 +49,7 @@ function zeile_faerben(type)
   end
 end
 
-function auswahl_faerben(type)
+function faerbeAuswahl(type)
   -- ändert Vordergrund- und Hintergrundfarbe der (bereits vorher erfolgten) Auswahl je nach Typ der Kommunikation
   local vg = farben.vg[type]
   local hg = farben.hg[type]

--- a/src/scripts/settings/Einstellungen/Farben.lua
+++ b/src/scripts/settings/Einstellungen/Farben.lua
@@ -1,20 +1,21 @@
 
-farben = {}
-farben.vg = 
+farben = farben or 
+{ vg =  
   { komm = "cyan",
     ebenen = "hot_pink",
     info = "green",
     alarm = "white",
     script = "dark_green",
-    gag = "dark_slate_gray" }
-farben.hg = 
+    gag = "dark_slate_gray" 
+  },
+  hg = 
   { komm = "black",
     ebenen = "black",
     info = "black", 
     alarm = "red",
     script = "black",
     gag = "black" }
-
+}
 -- komm: Kommunikation wie teile-mit
 -- ebenen: Einfaerben der "normalen" Ebenen
 -- info: Einfaerben von Informationen des Muds (Status Gegner)
@@ -24,16 +25,37 @@ farben.hg =
 
 -- Einstellungen fuer Farben Kampfscroll
 
-function msg (type, what)
-  -- setzt VG und HG je nach Typ der Kommunikation
+function text_faerben(type, text)
+  -- setzt Vordergrund- und Hintergrundfarbe je nach Typ der Kommunikation, und schreibt dann den Text in bunt 
   local vg = farben.vg[type]
   local hg = farben.hg[type]
-
   if vg and hg then
-      cecho("<"..vg..":"..hg..">"..what)
+    cecho("<"..vg..":"..hg..">"..text)
   else
     echo(what)
   end
 end
-                    
-                
+
+function zeile_faerben(type)
+  -- ändert Vordergrund- und Hintergrundfarbe der aktuellen (ganzen) Zeile je nach Typ der Kommunikation
+  -- Keine Ahnung, ob das besser geht, aber ich will die ganze Zeile einfärben und nicht nur den "Match".
+  local vg = farben.vg[type]
+  local hg = farben.hg[type]
+  if vg and hg then
+    selectCurrentLine()
+    fg(vg)
+    bg(hg)
+    resetFormat()
+  end
+end
+
+function auswahl_faerben(type)
+  -- ändert Vordergrund- und Hintergrundfarbe der (bereits vorher erfolgten) Auswahl je nach Typ der Kommunikation
+  local vg = farben.vg[type]
+  local hg = farben.hg[type]
+  if vg and hg then
+    fg(vg)
+    bg(hg)
+    resetFormat()
+  end
+end

--- a/src/triggers/krrrcks/Farb-Trigger/Alarm_Post.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Alarm_Post.lua
@@ -1,4 +1,1 @@
-selectCurrentLine()
-fg(farben.vg.alarm)
-bg(farben.hg.alarm)
-resetFormat()
+zeile_faerben("alarm")

--- a/src/triggers/krrrcks/Farb-Trigger/Alarm_Post.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Alarm_Post.lua
@@ -1,1 +1,1 @@
-zeile_faerben("alarm")
+faerbeZeile("alarm")

--- a/src/triggers/krrrcks/Farb-Trigger/Bewegung_Ausgaenge.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Bewegung_Ausgaenge.lua
@@ -1,4 +1,2 @@
 selectCaptureGroup(1)
-fg(farben.vg.info)
-bg(farben.hg.info)
-resetFormat()
+auswahl_faerben("info")

--- a/src/triggers/krrrcks/Farb-Trigger/Bewegung_Ausgaenge.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Bewegung_Ausgaenge.lua
@@ -1,2 +1,2 @@
 selectCaptureGroup(1)
-auswahl_faerben("info")
+faerbeAuswahl("info")

--- a/src/triggers/krrrcks/Farb-Trigger/Kampf_Flucht.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kampf_Flucht.lua
@@ -1,4 +1,1 @@
-selectCurrentLine()
-fg(farben.vg.info)
-bg(farben.hg.info)
-resetFormat()
+zeile_faerben("info")

--- a/src/triggers/krrrcks/Farb-Trigger/Kampf_Flucht.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kampf_Flucht.lua
@@ -1,1 +1,1 @@
-zeile_faerben("info")
+faerbeZeile("info")

--- a/src/triggers/krrrcks/Farb-Trigger/Kampf_Infos.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kampf_Infos.lua
@@ -1,4 +1,1 @@
-selectCurrentLine()
-fg(farben.vg.info)
-bg(farben.hg.info)
-resetFormat()
+zeile_faerben("info")

--- a/src/triggers/krrrcks/Farb-Trigger/Kampf_Infos.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kampf_Infos.lua
@@ -1,1 +1,1 @@
-zeile_faerben("info")
+faerbeZeile("info")

--- a/src/triggers/krrrcks/Farb-Trigger/Kampf_Zustand.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kampf_Zustand.lua
@@ -33,5 +33,5 @@ else
   ausgabe = " (???%)"
 end
 
-zeile_faerben("info")
-text_faerben("info", ausgabe)
+faerbeZeile("info")
+faerbeText("info", ausgabe)

--- a/src/triggers/krrrcks/Farb-Trigger/Kampf_Zustand.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kampf_Zustand.lua
@@ -33,8 +33,5 @@ else
   ausgabe = " (???%)"
 end
 
-selectCurrentLine()
-fg(farben.vg.info)
-bg(farben.hg.info)
-echo(ausgabe)
-resetFormat()
+zeile_faerben("info")
+text_faerben("info", ausgabe)

--- a/src/triggers/krrrcks/Farb-Trigger/Kommunikation.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kommunikation.lua
@@ -1,1 +1,1 @@
-zeile_faerben("komm")
+faerbeZeile("komm")

--- a/src/triggers/krrrcks/Farb-Trigger/Kommunikation.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Kommunikation.lua
@@ -1,7 +1,1 @@
--- Keine Ahnung, ob das besser geht, aber ich will die ganze Zeile einfärben und nicht nur
--- den "Match".
-
-selectCurrentLine()
-fg(farben.vg.komm)
-bg(farben.hg.komm)
-resetFormat()
+zeile_faerben("komm")

--- a/src/triggers/krrrcks/Farb-Trigger/Para_&_Normalwelt.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Para_&_Normalwelt.lua
@@ -1,19 +1,11 @@
 -- Prüfung über Portal 23
 
-selectCurrentLine()
-
 if (matches[3] == "gruenlich") then
-    fg(farben.vg.info)
-    bg(farben.hg.info)
-
+    zeile_faerben("info")
     ME.para = 0
-end
-
-if (matches[3] == "roetlich") then
-    fg(farben.vg.alarm)
-    bg(farben.hg.alarm)
+elseif (matches[3] == "roetlich") then
+    zeile_faerben("alarm")
     ME.para = 1
 end
 
 zeigeRaum()
-resetFormat()

--- a/src/triggers/krrrcks/Farb-Trigger/Para_&_Normalwelt.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Para_&_Normalwelt.lua
@@ -1,10 +1,10 @@
 -- Prüfung über Portal 23
 
 if (matches[3] == "gruenlich") then
-    zeile_faerben("info")
+    faerbeZeile("info")
     ME.para = 0
 elseif (matches[3] == "roetlich") then
-    zeile_faerben("alarm")
+    faerbeZeile("alarm")
     ME.para = 1
 end
 

--- a/src/triggers/krrrcks/Farb-Trigger/Suche_Bezugspunkt.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Suche_Bezugspunkt.lua
@@ -1,1 +1,1 @@
-zeile_faerben("gag")
+faerbeZeile("gag")

--- a/src/triggers/krrrcks/Farb-Trigger/Suche_Bezugspunkt.lua
+++ b/src/triggers/krrrcks/Farb-Trigger/Suche_Bezugspunkt.lua
@@ -1,4 +1,1 @@
-selectCurrentLine()
-fg(farben.vg.gag)
-bg(farben.hg.gag)
-resetFormat()
+zeile_faerben("gag")


### PR DESCRIPTION
Es gibt ja schon eine Farbtabelle in unserem Paket, aber bisher wurde die vorgesehene Funktion zur Ausgabe farbiger Texte nie benutzt.
Statt dessen hat jeder selbst in mehreren Zeilen die Farben aus der Tabelle gesucht und auf die jeweilige Auswahl oder Zeile oder neuen Text angewandt.

Ab sofort gibt es drei fertige Funktionen, um neuen Text, eine vorhandene Auswahl, oder die komplette Zeile einzufärben:
- text_faerben(type, text)
- zeile_faerben(type)
- auswahl_faerben(type)

Alle bisherigen Einfärbungen wurden auf die neue Syntax umgestellt und so deutlich robuster und kürzer gefasst.

Dabei entspricht type einem Namen aus der Farbtabelle also bisher:
```lua
-- komm: Kommunikation wie teile-mit
-- ebenen: Einfaerben der "normalen" Ebenen
-- info: Einfaerben von Informationen des Muds (Status Gegner)
-- alarm: Alarm-Nachrichten
-- script: Nachrichten, die nicht vom Mud, sondern von einem Script stammen.
-- gag: fast (!) unsichtbar auf schwarzem Hintergrund für unwichtigere Spieltexte.
```