### PR TITLE
Raum-Infos auf Mapper anzeigen

### DIFF
--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -31,6 +31,9 @@ registerMapInfo("Rauminfos", function()
 end)
 enableMapInfo("Rauminfos")
 
+ -- Standard-Anzeige im Mudlet-Mapper wird dann nicht benötigt
+disableMapInfo("Short")
+disableMapInfo("Full")
 
 function echoM(str)
     fg(mapperconf.color)

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -30,14 +30,13 @@ end)
 enableMapInfo("Region")
 
 -- Den aktuellen Kartenmodus in der Karte anzeigen
-registerMapInfo("Kartenmodus", function() 
-    if mapper.mode == "fix" then
-        return "Karte wird NICHT automatisch erweitert", false, true, 200, 200, 200
-    else
-        return "Karte wird automatisch erweitert", false, true, 200, 200, 200
-    end
+registerMapInfo("Modus", function() 
+    local mapper_modus = (mapper.mode == "fix") and 
+        "Karte wird NICHT automatisch erweitert" or
+        "Karte wird automatisch erweitert"
+    return mapper_modus, false, true, 200, 200, 200
 end)
-enableMapInfo("Kartenmodus")
+enableMapInfo("Modus")
 
 
  -- Standard-Anzeige im Mudlet-Mapper wird dann nicht benötigt

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -38,7 +38,6 @@ registerMapInfo("Modus", function()
 end)
 enableMapInfo("Modus")
 
-
  -- Standard-Anzeige im Mudlet-Mapper wird dann nicht benötigt
 disableMapInfo("Short")
 disableMapInfo("Full")

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -11,6 +11,16 @@ mapper.mode = mapper.mode or "fix"
 mapper.currentHash = mapper.currentHash or nil
 mapper.currentArea = mapper.currentArea or "world"
 
+-- Den aktuellen Raum und Regionsinfos in der Karte anzeigen
+registerMapInfo("Rauminfos", function() 
+    local raum_name = ME.raum_kurz
+    local region_infos = f"{ME.raum_region} [{ME.raum_id}]"
+    local r, g, b = 200, 200, 200
+    if ME.para > 0 then r, g, b = unpack(color_table.tomato) end
+    return f"{raum_name}\n{region_infos}", false, false, r, b, g
+end)
+enableMapInfo("Rauminfos")
+
 -- Den aktuellen Kartenmodus in der Karte anzeigen
 registerMapInfo("Kartenmodus", function() 
     if mapper.mode == "fix" then
@@ -21,15 +31,6 @@ registerMapInfo("Kartenmodus", function()
 end)
 enableMapInfo("Kartenmodus")
 
--- Den aktuellen Raum und Regionsinfos in der Karte anzeigen
-registerMapInfo("Rauminfos", function() 
-    local raum_name = ME.raum_kurz
-    local region_infos = f"{ME.raum_region} [{ME.raum_id}]"
-    local r, g, b = 200, 200, 200
-    if ME.para > 0 then r, g, b = unpack(color_table.tomato) end
-    return f"{raum_name}\n{region_infos}", false, false, r, b, g
-end)
-enableMapInfo("Rauminfos")
 
  -- Standard-Anzeige im Mudlet-Mapper wird dann nicht benötigt
 disableMapInfo("Short")

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -11,15 +11,23 @@ mapper.mode = mapper.mode or "fix"
 mapper.currentHash = mapper.currentHash or nil
 mapper.currentArea = mapper.currentArea or "world"
 
--- Den aktuellen Raum und Regionsinfos in der Karte anzeigen
-registerMapInfo("Rauminfos", function() 
+-- Die aktuellen Rauminfos in der Karte anzeigen
+registerMapInfo("Raum", function() 
     local raum_name = ME.raum_kurz
+    local r, g, b = 200, 200, 200
+    if ME.para > 0 then r, g, b = unpack(color_table.tomato) end
+    return raum_name, false, false, r, b, g
+end)
+enableMapInfo("Raum")
+
+-- Die aktuellen Regionsinfos in der Karte anzeigen
+registerMapInfo("Region", function() 
     local region_infos = f"{ME.raum_region} [{ME.raum_id}]"
     local r, g, b = 200, 200, 200
     if ME.para > 0 then r, g, b = unpack(color_table.tomato) end
-    return f"{raum_name}\n{region_infos}", false, false, r, b, g
+    return region_infos, false, false, r, b, g
 end)
-enableMapInfo("Rauminfos")
+enableMapInfo("Region")
 
 -- Den aktuellen Kartenmodus in der Karte anzeigen
 registerMapInfo("Kartenmodus", function() 

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -25,7 +25,7 @@ enableMapInfo("Kartenmodus")
 registerMapInfo("Rauminfos", function() 
     local raum_name = ME.raum_kurz
     local region_infos = f"{ME.raum_region} [{ME.raum_id}]"
-    local r, g, b = 30, 30, 30
+    local r, g, b = 200, 200, 200
     if ME.para > 0 then r, g, b = unpack(color_table.tomato) end
     return f"{raum_name}\n{region_infos}", false, false, r, b, g
 end)

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -21,6 +21,17 @@ registerMapInfo("Kartenmodus", function()
 end)
 enableMapInfo("Kartenmodus")
 
+-- Den aktuellen Raum und Regionsinfos in der Karte anzeigen
+registerMapInfo("Rauminfos", function() 
+    local raum_name = ME.raum_kurz
+    local region_infos = f"{ME.raum_region} [{ME.raum_id}]"
+    local r, g, b = 30, 30, 30
+    if ME.para > 0 then r, g, b = unpack(color_table.tomato) end
+    return f"{raum_name}\n{region_infos}", false, false, r, b, g
+end)
+enableMapInfo("Rauminfos")
+
+
 function echoM(str)
     fg(mapperconf.color)
     echo("[MAPPER] " .. str .. "\n")

--- a/src/scripts/mapper/Initialisierung.lua
+++ b/src/scripts/mapper/Initialisierung.lua
@@ -24,9 +24,9 @@ enableMapInfo("Rauminfos")
 -- Den aktuellen Kartenmodus in der Karte anzeigen
 registerMapInfo("Kartenmodus", function() 
     if mapper.mode == "fix" then
-        return "", false, true, unpack(color_table.tomato)
+        return "Karte wird NICHT automatisch erweitert", false, true, 200, 200, 200
     else
-        return "Kartenmodus: automatisch erweitern", false, true, unpack(color_table.tomato)
+        return "Karte wird automatisch erweitert", false, true, 200, 200, 200
     end
 end)
 enableMapInfo("Kartenmodus")


### PR DESCRIPTION
- [x] TODO: Prüfen, ob ME bei Bewegung schon rechtzeitig aktualisiert wurde und somit neuen Raum anzeigt, oder noch den alten. Dann ggf. direkt GMCP Daten abgreifen? Sind die dann schon aktuell? Sonst womöglich Suche über RaumID usw. nötig..!