### PR TITLE
Neue Keys für nordostoben, usw.

### DIFF
--- a/src/keys/krrrcks/Keypad/keys.json
+++ b/src/keys/krrrcks/Keypad/keys.json
@@ -44,6 +44,90 @@
     "command": "nordosten", 
     "keys": "keypad+9"
   },
+
+
+  {
+    "name": "ALT+1 suedwestoben", 
+    "command": "suedwestoben", 
+    "keys": "alt+keypad+1"
+  },
+  {
+    "name": "ALT+2 suedoben", 
+    "command": "suedoben", 
+    "keys": "alt+keypad+2"
+  },
+  {
+    "name": "ALT+3 suedostoben", 
+    "command": "suedostoben", 
+    "keys": "alt+keypad+3"
+  },
+  {
+    "name": "ALT+4 westoben", 
+    "command": "westoben", 
+    "keys": "alt+keypad+4"
+  },
+  {
+    "name": "ALT+6 ostoben", 
+    "command": "ostoben", 
+    "keys": "alt+keypad+6"
+  },
+  {
+    "name": "ALT+7 nordwestoben", 
+    "command": "nordwestoben", 
+    "keys": "alt+keypad+7"
+  },
+  {
+    "name": "ALT+8 nordoben", 
+    "command": "nordoben", 
+    "keys": "alt+keypad+8"
+  },
+  {
+    "name": "ALT+9 nordostoben", 
+    "command": "nordostoben", 
+    "keys": "alt+keypad+9"
+  },
+
+  {
+    "name": "STRG+1 suedwestunten", 
+    "command": "suedwestunten", 
+    "keys": "ctrl+keypad+1"
+  },
+  {
+    "name": "STRG+2 suedunten", 
+    "command": "suedunten", 
+    "keys": "ctrl+keypad+2"
+  },
+  {
+    "name": "STRG+3 suedostunten", 
+    "command": "suedostunten", 
+    "keys": "ctrl+keypad+3"
+  },
+  {
+    "name": "STRG+4 westunten", 
+    "command": "westunten", 
+    "keys": "ctrl+keypad+4"
+  },
+  {
+    "name": "STRG+6 ostunten", 
+    "command": "ostunten", 
+    "keys": "ctrl+keypad+6"
+  },
+  {
+    "name": "STRG+7 nordwestunten", 
+    "command": "nordwestunten", 
+    "keys": "ctrl+keypad+7"
+  },
+  {
+    "name": "STRG+8 nordunten", 
+    "command": "nordunten", 
+    "keys": "ctrl+keypad+8"
+  },
+  {
+    "name": "STRG+9 nordostunten", 
+    "command": "nordostunten", 
+    "keys": "ctrl+keypad+9"
+  },
+
   {
     "name": "0 schau", 
     "command": "schau", 

--- a/src/keys/krrrcks/Keypad/keys.json
+++ b/src/keys/krrrcks/Keypad/keys.json
@@ -1,8 +1,13 @@
 [
   {
-    "name": "0 schau", 
-    "command": "schau", 
+    "name": "0 inventar", 
+    "command": "inv", 
     "keys": "keypad+0"
+  },
+  {
+    "name": "5 schau", 
+    "command": "schau", 
+    "keys": "keypad+5"
   },
   {
     "name": ", ausruestung", 
@@ -48,11 +53,6 @@
     "name": "4 westen", 
     "command": "westen", 
     "keys": "keypad+4"
-  },
-  {
-    "name": "5 schau", 
-    "command": "schau", 
-    "keys": "keypad+5"
   },
   {
     "name": "6 osten", 

--- a/src/keys/krrrcks/Keypad/keys.json
+++ b/src/keys/krrrcks/Keypad/keys.json
@@ -1,5 +1,35 @@
 [
   {
+    "name": "0 schau", 
+    "command": "schau", 
+    "keys": "keypad+0"
+  },
+  {
+    "name": ", ausruestung", 
+    "command": "ausruestung", 
+    "keys": "keypad+,"
+  },
+  {
+    "name": "+ unten", 
+    "command": "unten", 
+    "keys": "keypad+plus"
+  },
+  {
+    "name": "- oben", 
+    "command": "oben", 
+    "keys": "keypad+-"
+  },
+  {
+    "name": "* raus", 
+    "command": "raus", 
+    "keys": "keypad+*"
+  },
+  {
+    "name": "÷ kurz", 
+    "keys": "keypad+/"
+  },
+
+  {
     "name": "1 suedwesten", 
     "command": "suedwesten", 
     "keys": "keypad+1"
@@ -66,6 +96,7 @@
     "command": "westoben", 
     "keys": "alt+keypad+4"
   },
+
   {
     "name": "ALT+6 ostoben", 
     "command": "ostoben", 
@@ -87,6 +118,7 @@
     "keys": "alt+keypad+9"
   },
 
+
   {
     "name": "STRG+1 suedwestunten", 
     "command": "suedwestunten", 
@@ -107,6 +139,7 @@
     "command": "westunten", 
     "keys": "ctrl+keypad+4"
   },
+
   {
     "name": "STRG+6 ostunten", 
     "command": "ostunten", 
@@ -126,35 +159,5 @@
     "name": "STRG+9 nordostunten", 
     "command": "nordostunten", 
     "keys": "ctrl+keypad+9"
-  },
-
-  {
-    "name": "0 schau", 
-    "command": "schau", 
-    "keys": "keypad+0"
-  },
-  {
-    "name": ", ausruestung", 
-    "command": "ausruestung", 
-    "keys": "keypad+,"
-  },
-  {
-    "name": "+ unten", 
-    "command": "unten", 
-    "keys": "keypad+plus"
-  },
-  {
-    "name": "- oben", 
-    "command": "oben", 
-    "keys": "keypad+-"
-  },
-  {
-    "name": "* raus", 
-    "command": "raus", 
-    "keys": "keypad+*"
-  },
-  {
-    "name": "÷ kurz", 
-    "keys": "keypad+/"
   }
 ]


### PR DESCRIPTION
- Ergänze neue Richtungen mit Modifikator: ALT für "oben" und STRG für "unten", also bspw.
  - STRG+Numpad+2 = suedunten,
  - ALT+Numpad+9 = nordostoben, usw.
- Sortiere Keys übersichtlicher: 
  - Zuerst "schau", usw. 
  - Dann die "normalen" Richtungen
  - Zuletzt die neuen modifizierten Richtungen
- Außerdem doppelt die Null nun nicht mehr die 5 ("schau")
  - sondern neu: die Null bringt jetzt das Inventar! 
  - (Das Komma zeigt weiterhin die Ausrüstung)

Dank an @Mundron und https://github.com/Mundron/MG_tools_public/