### PR TITLE
Ebenen je nach Name färben

### DIFF
--- a/src/scripts/GUI/Kommunikation/Ebenen/scripts.json
+++ b/src/scripts/GUI/Kommunikation/Ebenen/scripts.json
@@ -1,5 +1,8 @@
 [
     {
-        "name": "zeigeEbene"
+        "name": "zeigeEbene",
+        "eventHandlerList": [
+            "gmcp.comm.channel"
+          ]
     }
 ]

--- a/src/scripts/GUI/Kommunikation/Ebenen/zeigeEbene.lua
+++ b/src/scripts/GUI/Kommunikation/Ebenen/zeigeEbene.lua
@@ -1,12 +1,17 @@
 function zeigeEbene()
     if not table.is_field(gmcp, "comm.channel") then return end
 
+    local commData = gmcp.comm.channel
+    local chan = commData.chan
+    local player = commData.player
+    local msg = commData.msg
+    local bunterText = liefereFarbigeEbene(msg, player, chan)
+
     if GUI.Chatbox.Config.Ebenen.ShowInWindow then
-        local bunterText = liefereFarbigenText("ebenen", gmcp.comm.channel.msg)
-        GUI.Chatbox.EMCO:echo("Ebenen", bunterText)
+        GUI.Chatbox.EMCO:hecho("Ebenen", bunterText)
     end
 
     if GUI.Chatbox.Config.Ebenen.ShowInMain then
-        faerbeText("ebenen", gmcp.comm.channel.msg)
+        hecho("main", bunterText)
     end
 end

--- a/src/scripts/settings/Einstellungen/Farben.lua
+++ b/src/scripts/settings/Einstellungen/Farben.lua
@@ -2,7 +2,6 @@
 farben = farben or
 { vg =
   { komm = "cyan",
-    ebenen = "hot_pink",
     info = "green",
     alarm = "white",
     script = "dark_green",
@@ -10,7 +9,6 @@ farben = farben or
   },
   hg =
   { komm = "black",
-    ebenen = "black",
     info = "black",
     alarm = "red",
     script = "black",
@@ -68,4 +66,83 @@ function liefereFarbigenText(type, text)
     return("<"..vg..":"..hg..">"..text)
   end
   return(text)
+end
+
+function liefereFarbigeEbene(text, spieler, ebene)
+  -- setzt Spieler und Ebenenname im gegebenen Text bunt für hecho()
+  -- Pattern muss [ und ] escapen mit % da hier Lua Regex zugrunde liegt
+  -- Das ] ist absichtlich nicht enthalten, damit Emotes erkannt werden.
+  local pattern = f"%[{ebene}:{spieler}"
+  local colored_text = f"[{color_text_for_hecho(ebene)}:{color_text_for_hecho(spieler)}"
+  return text:gsub(pattern, colored_text)
+end
+
+-- Inspiration:
+-- - https://stackoverflow.com/questions/3426404/create-a-hexadecimal-colour-based-on-a-string-with-javascript
+-- - https://stackoverflow.com/questions/68317097/how-to-properly-convert-hsl-colors-to-rgb-colors-in-lua
+
+function color_text_for_hecho(string_input)
+  local red, green, blue = string_to_color(string_input)
+  local hecho_format = f"#{math.DecToHex(red)}{math.DecToHex(green)}{math.DecToHex(blue)}{string_input}#r"
+  return hecho_format
+end
+
+--- Give a string, and receive always the same but random color for it (in hecho() format)
+-- @param string_input What text you want to get a color for
+-- @param[opt=100] saturation How saturated the color should become
+-- @param[opt=75] lightness How light the new color should become
+function string_to_color(string_input, saturation, lightness)
+  local hash = 0
+  local saturation = saturation or 100
+  local lightness = lightness or 75
+  for i = 1, #string_input do
+    hash = string.byte(string_input, i) + ((hash * 32) - hash)
+  end
+  local hue = hash % 360
+  local red, green, blue = HSL_to_RGB(hue, saturation, lightness)
+  return red, green, blue
+end
+
+--- Convert a color from HSL format to RGB format
+-- @param hue Given in a range from 0 to 360
+-- @param saturation Given in a range from 0 to 100
+-- @param lightness Given in a range from 0 to 100
+-- @return red Given in a range from 0 to 255
+-- @return green Given in a range from 0 to 255
+-- @return blue Given in a range from 0 to 255
+function HSL_to_RGB(hue, saturation, lightness)
+    local h = hue / 360
+    local s = saturation / 100
+    local l = lightness / 100
+    local r, g, b;
+
+    if s == 0 then
+        r, g, b = l, l, l; -- achromatic
+    else
+        local function hue2rgb(p, q, t)
+            if t < 0 then t = t + 1 end
+            if t > 1 then t = t - 1 end
+            if t < 1 / 6 then return p + (q - p) * 6 * t end
+            if t < 1 / 2 then return q end
+            if t < 2 / 3 then return p + (q - p) * (2 / 3 - t) * 6 end
+            return p;
+        end
+
+        local q = l < 0.5 and l * (1 + s) or l + s - l * s;
+        local p = 2 * l - q;
+        r = hue2rgb(p, q, h + 1 / 3);
+        g = hue2rgb(p, q, h);
+        b = hue2rgb(p, q, h - 1 / 3);
+    end
+
+    return math.round(r * 255), math.round(g * 255), math.round(b * 255)
+end
+
+function math.round(num, numDecimalPlaces)
+  local mult = 10^(numDecimalPlaces or 0)
+  return math.floor(num * mult + 0.5) / mult
+end
+
+function math.DecToHex(num)
+  return string.format("%x", num)
 end

--- a/src/scripts/settings/Einstellungen/Farben.lua
+++ b/src/scripts/settings/Einstellungen/Farben.lua
@@ -23,8 +23,8 @@ farben = farben or
 
 -- Einstellungen fuer Farben Kampfscroll
 
+--- Setzt Vordergrund- und Hintergrundfarbe je nach Typ der Kommunikation, und schreibt dann den Text in bunt
 function faerbeText(type, text)
-  -- setzt Vordergrund- und Hintergrundfarbe je nach Typ der Kommunikation, und schreibt dann den Text in bunt
   local vg = farben.vg[type]
   local hg = farben.hg[type]
   if vg and hg then
@@ -34,9 +34,9 @@ function faerbeText(type, text)
   end
 end
 
+--- Ändert Vordergrund- und Hintergrundfarbe der aktuellen (ganzen) Zeile je nach Typ der Kommunikation
+-- Keine Ahnung, ob das besser geht, aber ich will die ganze Zeile einfärben und nicht nur den "Match".
 function faerbeZeile(type)
-  -- ändert Vordergrund- und Hintergrundfarbe der aktuellen (ganzen) Zeile je nach Typ der Kommunikation
-  -- Keine Ahnung, ob das besser geht, aber ich will die ganze Zeile einfärben und nicht nur den "Match".
   local vg = farben.vg[type]
   local hg = farben.hg[type]
   if vg and hg then
@@ -47,8 +47,8 @@ function faerbeZeile(type)
   end
 end
 
+--- Ändert Vordergrund- und Hintergrundfarbe der (bereits vorher erfolgten) Auswahl je nach Typ der Kommunikation
 function faerbeAuswahl(type)
-  -- ändert Vordergrund- und Hintergrundfarbe der (bereits vorher erfolgten) Auswahl je nach Typ der Kommunikation
   local vg = farben.vg[type]
   local hg = farben.hg[type]
   if vg and hg then
@@ -58,8 +58,8 @@ function faerbeAuswahl(type)
   end
 end
 
+--- Setzt Vordergrund- und Hintergrundfarbe je nach Typ der Kommunikation, und schreibt dann den Text in bunt
 function liefereFarbigenText(type, text)
-  -- setzt Vordergrund- und Hintergrundfarbe je nach Typ der Kommunikation, und schreibt dann den Text in bunt
   local vg = farben.vg[type]
   local hg = farben.hg[type]
   if vg and hg then
@@ -68,22 +68,28 @@ function liefereFarbigenText(type, text)
   return(text)
 end
 
+--- Setzt Namen von Spieler und Ebene im gegebenen Text bunt für hecho()
+-- Pattern muss [ und ] escapen mit % da hier Lua Regex zugrunde liegt
+-- Das ] ist absichtlich nicht enthalten, damit Emotes erkannt werden.
+-- @param text Text einer Ebene inkl. Senderkennung wie: [Tod:Lars] Huhu!
+-- @param spieler Wer schreibt auf der Ebene? Bspw. Lars
+-- @param ebene Auf welcher Ebene wird geschrieben? Bspw. Tod
+-- @return farbigerText Derselbe Text, nur in Farbe!
 function liefereFarbigeEbene(text, spieler, ebene)
-  -- setzt Spieler und Ebenenname im gegebenen Text bunt für hecho()
-  -- Pattern muss [ und ] escapen mit % da hier Lua Regex zugrunde liegt
-  -- Das ] ist absichtlich nicht enthalten, damit Emotes erkannt werden.
   local pattern = f"%[{ebene}:{spieler}"
   local colored_text = f"[{color_text_for_hecho(ebene)}:{color_text_for_hecho(spieler)}"
   return text:gsub(pattern, colored_text)
 end
 
--- Inspiration:
+--- Färbt den gegebenen Text in seine einzigartige Farbe (vorbereitet zur Ausgabe per hecho())
+-- Inspiration, um Farben aus Text abzuleiten:
 -- - https://stackoverflow.com/questions/3426404/create-a-hexadecimal-colour-based-on-a-string-with-javascript
 -- - https://stackoverflow.com/questions/68317097/how-to-properly-convert-hsl-colors-to-rgb-colors-in-lua
-
-function color_text_for_hecho(string_input)
-  local red, green, blue = string_to_color(string_input)
-  local hecho_format = f"#{math.DecToHex(red)}{math.DecToHex(green)}{math.DecToHex(blue)}{string_input}#r"
+-- @param text Beliebiger Text, der gefärbt werden soll
+-- @return farbigerText Derselbe Text, nur in Farbe! Am Ende wird Format zurückgesetzt.
+function color_text_for_hecho(text)
+  local red, green, blue = string_to_color(text)
+  local hecho_format = f"#{math.DecToHex(red)}{math.DecToHex(green)}{math.DecToHex(blue)}{text}#r"
   return hecho_format
 end
 
@@ -138,11 +144,18 @@ function HSL_to_RGB(hue, saturation, lightness)
     return math.round(r * 255), math.round(g * 255), math.round(b * 255)
 end
 
+--- Rundet auf/ab, anstatt einfach nur ab wie math.floor()
+-- @param num Die zu rundende Zahl
+-- @param numDecimalPlaces[opt=0] Anzahl der Dezimalstellen
+-- @return roundedNumber Die auf-/abgerundete Zahl
 function math.round(num, numDecimalPlaces)
   local mult = 10^(numDecimalPlaces or 0)
   return math.floor(num * mult + 0.5) / mult
 end
 
+--- Wandelt eine Dezimalzahl in eine Hexadezimalzahl um
+-- @param num Die zu wandelnde Dezimalzahl
+-- @return numAsHex Die hexadezimale Darstellung der Zahl als String
 function math.DecToHex(num)
   return string.format("%x", num)
 end


### PR DESCRIPTION
Statt wie bisher jede Zeile von jedem Spieler auf jeder Ebene in rosa einzufärben, wird es nun bunter:
- Der Name des Spielers wird zufällig (aber immer gleich für ihn) eingefärbt
- Der Name der Ebene wird ebenfalls so zufällig eingefärbt
- Der Rest der Nachricht wird nicht mehr eingefärbt

Vorher:

![image](https://user-images.githubusercontent.com/117238/221384663-1c770387-feee-4016-bc53-0005230edf6e.png)

Jetzt:

![image](https://user-images.githubusercontent.com/117238/221384668-4516072b-827f-47a1-8bc4-0f110336f1e2.png)

Dazu einige hilfreiche Funktionen eingebaut:
- liefereFarbigeEbene(text, spieler, ebene) --> Liefert den gleichen Text zurück aber mit Namen von Spieler und Ebene bunt gefärbt (vorbereitet zur Ausgabe per `hecho()`)
- color_text_for_hecho(text) --> Färbt den gegebenen Text in seine einzigartige Farbe (vorbereitet zur Ausgabe per `hecho()`)
- string_to_color(string_input, saturation, lightness) --> Liefert einzigartige RGB Farbcodes für den gegebenen Text (saturation und lightness sind optional und voreingestellt auf 100 und 75)
- HSL_to_RGB(hue, saturation, lightness) --> liefert RGB Farbcodes für den gegebenen HSL Farbcode
- math.round(num, numDecimalPlaces) --> rundet auf/ab, anstatt einfach nur ab wie math.floor. Optional kann die Anzahl der Dezimalstellen angegeben werden (sonst bleibt sie 0)
- math.DecToHex(num) --> wandelt die gegebene Dezimalzahl in einer hexadezimale Darstellung als String um