### PR TITLE
Chatbox heißt jetzt nur Chat

### DIFF
--- a/src/scripts/GUI/Drache/Actions/GUIReset.lua
+++ b/src/scripts/GUI/Drache/Actions/GUIReset.lua
@@ -6,7 +6,7 @@ function GUIReset()
     -- TODO: Bald wird initGUI() stattdessen die komplette GUI bauen.
     -- Dann sind die folgenden Zeilen vmtl. obsolet und Teil von dort:
     initMapperbox()
-    initChatbox()
+    initChat()
     initDrache()
 
     initGMCP("", "GMCP")

--- a/src/scripts/GUI/Kommunikation/Ebenen/zeigeEbene.lua
+++ b/src/scripts/GUI/Kommunikation/Ebenen/zeigeEbene.lua
@@ -7,11 +7,11 @@ function zeigeEbene()
     local msg = commData.msg
     local bunterText = liefereFarbigeEbene(msg, player, chan)
 
-    if GUI.Chatbox.Config.Ebenen.ShowInWindow then
-        GUI.Chatbox.EMCO:hecho("Ebenen", bunterText)
+    if GUI.Chat.Config.Ebenen.ShowInWindow then
+        GUI.Chat.EMCO:hecho("Ebenen", bunterText)
     end
 
-    if GUI.Chatbox.Config.Ebenen.ShowInMain then
+    if GUI.Chat.Config.Ebenen.ShowInMain then
         hecho("main", bunterText)
     end
 end

--- a/src/scripts/GUI/Kommunikation/Mitteilungen/zeigeMitteilung.lua
+++ b/src/scripts/GUI/Kommunikation/Mitteilungen/zeigeMitteilung.lua
@@ -1,13 +1,13 @@
 function zeigeMitteilung()
 
-    if GUI.Chatbox.Config.Mitteilungen.ShowInWindow then
+    if GUI.Chat.Config.Mitteilungen.ShowInWindow then
       selectCurrentLine()
-      GUI.Chatbox.EMCO:append("Mitteilungen")
+      GUI.Chat.EMCO:append("Mitteilungen")
       deselect()
       resetFormat()
     end
 
-    if not GUI.Chatbox.Config.Mitteilungen.ShowInMain then
+    if not GUI.Chat.Config.Mitteilungen.ShowInMain then
       deleteLine()
     end
 


### PR DESCRIPTION
Da war doch glatt die Kommunikation ausgefallen.
Wurden keine Mitteilungen und Ebenen mehr angezeigt.
Wer hat das bitte getestet und freigegeben?