### PR TITLE
Beim Schließen das Char-Layout nicht zerstören

### DIFF
--- a/src/scripts/GUI/Charakter/initCharFrame.lua
+++ b/src/scripts/GUI/Charakter/initCharFrame.lua
@@ -45,7 +45,7 @@ end
 function onExitCharGUI()
   -- Workaround, da sonst beim nächsten Laden des Profils das Layout kaputt geht
   --   vgl. https://github.com/Mudlet/Mudlet/issues/5321
-  GUI.Char.Clone:toggleFixedSize(false)
+  GUI.Char.Frame:toggleFixedSize(false)
 end
 exitCharHandler = exitCharHandler or
   registerAnonymousEventHandler("sysExitEvent", "onExitCharGUI")


### PR DESCRIPTION
Derzeit gibt es einen miesen Bug, der dazu führt, dass das Char-Layout sich ohne Zutun des Spielers einfach selbst zerstört.

Beim ersten Start des Pakets sieht die Char Box unten links noch ganz normal aus (Hier vor Login daher ohne Inhalt):
![image](https://user-images.githubusercontent.com/117238/229316041-61fae86d-06c7-452c-8169-45f96617bec6.png)


Beim zweiten Start hat sie sich über die komplette Breite des unteren Bereichs erstreckt und lässt sich nicht verkleinern:
![image](https://user-images.githubusercontent.com/117238/229316038-9cf990b2-df6a-4d4f-817f-e560af094282.png)


Mit dem Fix aus diesem PR bleibt sie auch beim zweiten Start wie erwartet klein, lässt sich verschieben, verändern, usw.:
![image](https://user-images.githubusercontent.com/117238/229316035-3d3fef7e-d7ef-402d-a5df-856b4d2c8c89.png)

(Box erscheint hier etwas kleiner als im ersten Screenshot, da ich sie als Demo nur von Hand wieder klein gezogen hatte)