### PR TITLE
Mapper-Debug-Infos im Hauptfenster anzeigen, falls EMCO fehlen sollte

### DIFF
--- a/src/scripts/GUI/Kommunikation/Debug/mapper.lua
+++ b/src/scripts/GUI/Kommunikation/Debug/mapper.lua
@@ -1,4 +1,9 @@
 function echoM(text)
     local bunterText = liefereFarbigenText("mapper", "[MAPPER]  - " .. text .. "\n")
-    GUI.Chat.EMCO:cecho("Debug", bunterText)
+    if GUI.Chat.EMCO then
+        GUI.Chat.EMCO:cecho("Debug", bunterText)
+    else
+        -- Anscheinend wurde EMCO (noch?) nicht eingerichtet - schreibe dann ins Hauptfenster
+        cecho("Debug", bunterText)
+    end
 end


### PR DESCRIPTION
Leider kann [muddler](https://github.com/demonnic/muddler/issues/14) ja noch nicht die Reihenfolge der Ordner garantieren. Hier hatte demonnic Besserung zugesagt.
Daher kann es beim Start vorkommen, dass echoM() etwas an EMCO senden will, das aber noch nicht existiert.
Zukünftig wird echoM() dann einfach die Infos ins Hauptfenster schreiben, damit sie nicht verloren gehen.