### PR TITLE
Bei erneuter Verbindung GMCP wiederherstellen

### DIFF
--- a/src/scripts/Setup/onConnect.lua
+++ b/src/scripts/Setup/onConnect.lua
@@ -1,0 +1,6 @@
+function onConnect(_, packageName)
+    -- alles was bei Verbindung zum Spiel getan werden soll
+
+    initGMCP("", "GMCP")
+
+end

--- a/src/scripts/Setup/scripts.json
+++ b/src/scripts/Setup/scripts.json
@@ -23,5 +23,10 @@
         "eventHandlerList": [
             "sysExitEvent"
           ]
+    },{
+        "name": "onConnect",
+        "eventHandlerList": [
+            "sysConnectionEvent"
+          ]
     }
 ]


### PR DESCRIPTION
Derzeit wird bspw. Ebenen nicht mehr richtig erkannt (weil sie nicht mehr per GMCP kommen), nachdem man sich neu verbindet.

Dieser PR repariert das, indem GMCP bei jeder neuen Verbindung nochmal neu angefordert wird.