### PR TITLE
Titel zentrieren

### DIFF
--- a/src/scripts/GUI/Karte/initMapperbox.lua
+++ b/src/scripts/GUI/Karte/initMapperbox.lua
@@ -26,6 +26,7 @@ function initMapperbox()
         buttonFontSize = 8,
         buttonsize = 16,
         titleText = "Karte",
+        titleFormat = "c",
         titleTxtColor = "SaddleBrown",
         attached = "right",
         }

--- a/src/scripts/GUI/Kommunikation/initChat.lua
+++ b/src/scripts/GUI/Kommunikation/initChat.lua
@@ -36,6 +36,7 @@ function initChat()
             buttonFontSize = 8,
             buttonsize = 16,
             titleText = "Kommunikation",
+            titleFormat = "c",
             titleTxtColor = "SaddleBrown",
             attached = "right",
     })  -- Position unterhalb Mapperbox!


### PR DESCRIPTION
Vorher: 
"Karte" und "Kommunikation" werden links angezeigt
![grafik](https://github.com/user-attachments/assets/3eae6de8-00be-42c2-97ff-c326fcf35461)


Neu: 
Die Titel werden in der Mitte angezeigt
![grafik](https://github.com/user-attachments/assets/f33d88e8-dfaa-4fa2-8688-68439974b728)
