### PR TITLE
FluchtLabel wird nicht mehr überdeckt

### DIFF
--- a/src/scripts/GUI/Charakter/Flucht.lua
+++ b/src/scripts/GUI/Charakter/Flucht.lua
@@ -1,7 +1,7 @@
 function initFlucht()
   GUI.Char.FluchtLabel = Geyser.Label:new({
     name = "FluchtLabel", fgColor = "white",
-    x = 64, y = 56, padding = 0,width = 170, height = 17
+    x = 74, y = 56, padding = 0,width = 160, height = 17
   }, GUI.Char.Frame)
   GUI.Char.FluchtLabel:setStyleSheet([[
     border-color: rgba(0, 0, 0, 0%);


### PR DESCRIPTION
Fix #105

Problem: (siehe Bugreport)

Lösung: 
<img width="247" height="82" alt="grafik" src="https://github.com/user-attachments/assets/f65d7190-a507-45ea-b808-59743535c8b2" />
